### PR TITLE
chore: pin bun to v1.3 and add minimumReleaseAge

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[install]
+minimumReleaseAge = 172800
+minimumReleaseAgeExcludes = ["@nuxt/*", "@nuxtjs/*", "nuxt", "nuxt-*", "@vercel/*", "@ai-sdk/*", "ai"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hrcd/cli-starter",
   "version": "0.2.0",
+  "packageManager": "bun@1.3.14",
   "type": "module",
   "description": "default repository for HugoRCD",
   "author": "HugoRCD",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hrcd/cli-starter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "packageManager": "bun@1.3.14",
   "type": "module",
   "description": "default repository for HugoRCD",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import process from 'node:process'
 import { program } from './main'
 
 program.parse(process.argv)


### PR DESCRIPTION
## Summary

Two related changes to harden the supply chain.

### 1. Pin bun to v1.3

Add `packageManager: bun@1.3.14` to `package.json`. Required to use the `minimumReleaseAge` setting added in bun 1.3.

### 2. Add `minimumReleaseAge` to harden supply chain

New `bunfig.toml`:
```toml
[install]
minimumReleaseAge = 172800
minimumReleaseAgeExcludes = ["@nuxt/*", "@nuxtjs/*", "nuxt", "nuxt-*", "@vercel/*", "@ai-sdk/*", "ai"]
```

Sets a 2-day minimum age (172800 seconds) before any newly published dependency can resolve. Trusted-source allowlist exempts the Nuxt and Vercel ecosystems.

## Test plan
- [ ] `bun install` resolves cleanly with v1.3.14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package manager to Bun 1.3.14 and bumped package version to 0.2.1
  * Tuned package installation configuration to adjust release-age handling and exclusions
  * Improved CLI startup/argument parsing reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/cli-starter/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->